### PR TITLE
bugfixing grep2awk.plugin.zsh

### DIFF
--- a/grep2awk.plugin.zsh
+++ b/grep2awk.plugin.zsh
@@ -4,4 +4,4 @@
 
 autoload -Uz grep2awk
 zle -N grep2awk
-bindkey ${GREP2AWK_KEY:-^X^A} grep2awk
+bindkey ${GREP2AWK_KEY:-\^X\^A} grep2awk


### PR DESCRIPTION
When using ```zplug``` the old version doesn't load...